### PR TITLE
Feature - Expand Orders

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -73,11 +73,10 @@ class JSONServer(HandleRequests):
                 successfully_deleted = delete_order(pk)
                 if successfully_deleted:
                     return self.response("", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value)
-                
+
                 return self.response("Requested resource not found", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value)
 
-        else:
-            return self.response("Not found", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value)
+        return self.response("Not found", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value)
 
 
 def main():

--- a/views/order_view.py
+++ b/views/order_view.py
@@ -11,14 +11,49 @@ def get_orders():
                 o.id,
                 o.metal_id,
                 o.size_id,
-                o.style_id
+                o.style_id,
+                m.metal,
+                m.price AS metal_price,
+                s.carat,
+                s.price AS size_price,
+                st.style,
+                st.price AS style_price
             FROM Orders o
+            JOIN Metals m ON m.id = o.metal_id
+            JOIN Sizes s ON s.id = o.size_id
+            JOIN Styles st ON st.id = o.style_id
         """)
         query_results = db_cursor.fetchall()
 
         orders = []
         for row in query_results:
-            orders.append(dict(row))
+            order = {
+                "id": row["id"],
+                "metal_id": row["metal_id"],
+                "size_id": row["size_id"],
+                "style_id": row["style_id"]
+            }
+            metal = {
+                "id": row["metal_id"],
+                "metal": row["metal"],
+                "price": row["metal_price"]
+            }
+            size = {
+                "id": row["size_id"],
+                "carat": row["carat"],
+                "price": row["size_price"]
+            }
+            style = {
+                "id": row["style_id"],
+                "style": row["style"],
+                "price": row["style_price"]
+            }
+
+            order["metal"] = metal
+            order["size"] = size
+            order["style"] = style
+
+            orders.append(order)
 
         serialized_orders = json.dumps(orders)
 

--- a/views/order_view.py
+++ b/views/order_view.py
@@ -70,13 +70,53 @@ def get_single_order(url):
                 o.id,
                 o.metal_id,
                 o.size_id,
-                o.style_id
+                o.style_id,
+                m.metal,
+                m.price AS metal_price,
+                s.carat,
+                s.price AS size_price,
+                st.style,
+                st.price AS style_price
             FROM Orders o
+            JOIN Metals m ON m.id = o.metal_id
+            JOIN Sizes s ON s.id = o.size_id
+            JOIN Styles st ON st.id = o.style_id
             WHERE o.id = ?
         """, (order_id,))
         query_result = db_cursor.fetchone()
 
-        serialized_order = json.dumps(dict(query_result))
+        order = {}
+        if query_result:
+            order = {
+                "id": query_result["id"],
+                "metal_id": query_result["metal_id"],
+                "size_id": query_result["size_id"],
+                "style_id": query_result["style_id"]
+            }
+            metal = {
+                "id": query_result["metal_id"],
+                "metal": query_result["metal"],
+                "price": query_result["metal_price"]
+            }
+            size = {
+                "id": query_result["size_id"],
+                "carat": query_result["carat"],
+                "price": query_result["size_price"]
+            }
+            style = {
+                "id": query_result["style_id"],
+                "style": query_result["style"],
+                "price": query_result["style_price"]
+            }
+
+            order["metal"] = metal
+            order["size"] = size
+            order["style"] = style
+
+        else:
+            order = None
+
+        serialized_order = json.dumps(order)
 
     return serialized_order
 


### PR DESCRIPTION
### Purpose
To embed data related to Orders when making GET requests for one or more Orders

### Files Changed
- Updated get_orders and get_single_order methods to embed Metal, Size, and Style into each Order in `order_view.py`
- Cleaned up code in `json-server.py`

### To Test
Fetch, create or recreate database, and run `json-server.py`, then confirm the following
- GET request `/Orders` returns all Orders, embedding the related Metal, Size, and Style in each Order
- GET request `/Orders/{id}` returns the appropriate Order, and embeds the related Metal, Size, and Style